### PR TITLE
[GPU] Set current LCD Mode to 0 when LCD is disabled - fixing Dr Mario

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -103,6 +103,17 @@ Currently those tests are run manually, but in future those will run automatical
 
 ![fairy-lake](https://user-images.githubusercontent.com/11317951/130689865-4e40389b-05b2-4b87-b90d-eafb10f6ddff.png)
 
+# Runnable ROMs
+
+## MBC 0
+
+### Tetris:
+![tetris_title_screen](https://user-images.githubusercontent.com/11317951/131384273-51fcbd45-76cb-49d3-8fb9-a2cee06184de.png)
+![tetris_running_game](https://user-images.githubusercontent.com/11317951/131384290-57be00dd-1eca-4441-b268-97d55c752561.png)
+
+### Dr Mario:
+![dr_mario_title_screen](https://user-images.githubusercontent.com/11317951/131384319-be6c966a-7ace-4d9e-8456-6b64deaff346.png)
+![dr_mario_running](https://user-images.githubusercontent.com/11317951/131384322-1f7d296c-5f1e-4537-b310-bd5326dcff2e.png)
 
 # Knowledge list - articles / tutorials / videos / specs / repos / test ROMs:
 

--- a/core/src/components/gpu/gpu.spec.ts
+++ b/core/src/components/gpu/gpu.spec.ts
@@ -15,7 +15,7 @@ describe("initialize", () => {
 });
 
 describe("update when LCD disabled", () => {
-    test("should reset LY_REGISTER and set LCD Mode to 1", () => {
+    test("should reset LY_REGISTER and set LCD Mode to 0", () => {
         const eventBus = new EventBus();
         const memory = new Memory(eventBus);
         memory.directWrite8BitsValue(REGISTERS.GPU.LY_REGISTER, 128);
@@ -26,7 +26,7 @@ describe("update when LCD disabled", () => {
         gpu.update(100);
 
         expect(memory.read8BitsValue(REGISTERS.GPU.LY_REGISTER)).toBe(0);
-        expect(memory.read8BitsValue(REGISTERS.GPU.LCD_STAT_REGISTER)).toBe(0b11111101);
+        expect(memory.read8BitsValue(REGISTERS.GPU.LCD_STAT_REGISTER)).toBe(0b11111100);
     })
 });
 

--- a/core/src/components/gpu/gpu.ts
+++ b/core/src/components/gpu/gpu.ts
@@ -91,17 +91,17 @@ class GPU {
 
     private setupLCDWhenDisabled = () => {
         this.ticks = 0;
-        // when LCD is disabled then mode should be set to VBLANK (1)
+        // when LCD is disabled then mode should be set to 0 (HBLANK)
         // and scanline should be reset. In other cases some games such as
         // Mario2 won't play past title screen
         
         // writing anything via memory to LY_REGISTER resets it anyway
         this.memory.write8BitsValue(REGISTERS.GPU.LY_REGISTER, 0);
         
-        // set mode to 1 (VBLANK)
-        // binary 01
+        // set mode to 0 (HBLANK)
+        // binary 00
         let status = this.memory.read8BitsValue(REGISTERS.GPU.LCD_STAT_REGISTER);
-        status = numberUtils.setBit(status, 0);
+        status = numberUtils.unsetBit(status, 0);
         status = numberUtils.unsetBit(status, 1);
         this.memory.write8BitsValue(REGISTERS.GPU.LCD_STAT_REGISTER, status);
 


### PR DESCRIPTION
# What:  
Setting current LCD Mode to 0 (HBLANK) when LCD is disabled. Setting it to Mode 1 (VBLANK) was causing Dr Mario to not enable LCD ever again after tile screen